### PR TITLE
consistency + fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 ## A list of FOSS backup software
 
-
-
 |Name | Implemented in | GUI | License |
 ------|----------------|-----|---------|
 | [burp](https://github.com/grke/burp)  |  C |   Unix,Mac,Windows,Web   | AGPLv3  |
@@ -14,10 +12,10 @@
 | [borg](https://github.com/borgbackup/borg) | Python3 | CLI, Web        | BSD     |
 | [zbackup](http://zbackup.org/)            | C++      | CLI             | GPLv2   |
 | [bup](https://github.com/bup/bup) | Python2|  CLI, GTK, QT |           GPLv2     |
-| [restic](http://restic.github.io) | GoLang | CLI  |  BSD 2 Clause |
+| [restic](http://restic.github.io) | Go | CLI  |  BSD 2 Clause |
 | [git-annex-assistant](https://git-annex.branchable.com/assistant/)| Haskell | Unix,Mac,Windows, Web, Android |AGPL\GPL |
 | [poppins](https://bitbucket.org/poppins/poppins) | PHP (ssh,rsync) | CLI | GPLv3
-| [syncthing](https://github.com/syncthing/syncthing) | GoLang |CLI, Web, Android, GTK |  MPLv2 |
+| [syncthing](https://github.com/syncthing/syncthing) | Go |CLI, Web, Android, GTK |  MPLv2 |
 | [btrbk](https://github.com/digint/btrbk)| Perl | CLI | GPLv3 |
 | [rdedup](https://github.com/dpc/rdedup.git) | Rust | CLI | MPL-2 |
 | [knoxite](https://github.com/knoxite/knoxite) | Go  | CLI  | AGPLv3 |
@@ -38,7 +36,5 @@
 Know any good backup Software? Make a PR! I'll add it here!
 
 This list is intended to advocate Free Software
-Backup solution, and is dedicated to all those gone hourse I spent monitoring 
+Backup solutions, and is dedicated to all those gone hours I spent monitoring 
 TSM.
-
-


### PR DESCRIPTION
consistently use "Go" rather than switching between "GoLang" and "Go", also fix a few other minor typos